### PR TITLE
Ajuste do limite de tempo para Expiração em Anos

### DIFF
--- a/src/PagSeguroAssinaturas.php
+++ b/src/PagSeguroAssinaturas.php
@@ -144,7 +144,7 @@ class PagSeguroAssinaturas extends PagSeguroBase {
 	* @var array
 	*/
 	private $expiracao = array(
-		'value' => 1000000,
+		'value' => 999, // LIMITE ATUAL DO PAGSEGURO PARA EXPIRATION TIME 
 		'unit'	=> 'YEARS' //YEARS|MONTHS|DAYS
 	);
 


### PR DESCRIPTION
O Pagseguro ajustou o limite dele para 1 até 999 anos, vale ajustar o campo para evitar erros em caso de valor default :)